### PR TITLE
Device interface generic stream individual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ __pycache__/
 
 # build
 build*
-/twister-out*
+twister-out*
 cmake-build-*/
 
 # documentation

--- a/include/astarte_device_sdk/device.h
+++ b/include/astarte_device_sdk/device.h
@@ -26,6 +26,7 @@
 #include "astarte_device_sdk/error.h"
 #include "astarte_device_sdk/interface.h"
 #include "astarte_device_sdk/pairing.h"
+#include "astarte_device_sdk/type.h"
 
 /** @brief Max allowed hostname characters are 253 */
 #define ASTARTE_MAX_MQTT_BROKER_HOSTNAME_LEN 253
@@ -142,12 +143,13 @@ extern "C" {
  * @brief Allocate a new instance of an Astarte device.
  *
  * @details This function has to be called to initialize the device SDK before doing anything else.
+ * If an error code is returned the astarte_device_free function must not be called.
  *
  * @note A device can be instantiated and connected to Astarte only if it has been previously
  * registered on Astarte.
  *
  * @param[in] cfg Configuration struct.
- * @param[out] handle Device instance inizialized.
+ * @param[out] handle Device instance initialized.
  * @return ASTARTE_OK if successful, otherwise an error code.
  */
 astarte_err_t astarte_device_new(astarte_device_config_t *cfg, astarte_device_handle_t *handle);
@@ -179,19 +181,18 @@ astarte_err_t astarte_device_connect(astarte_device_handle_t device);
 astarte_err_t astarte_device_poll(astarte_device_handle_t device);
 
 /**
- * @brief Publish BSON formatted data.
- *
- * @warning TODO remove this function once TX API is complete.
+ * @brief Send an individual value through the device connection.
  *
  * @param[in] device Handle to the device instance.
  * @param[in] interface_name Interface where to publish data.
  * @param[in] path Path where to publish data.
- * @param[in] bson Data to publish.
+ * @param[in] value Correctly initialized astarte value.
+ * @param[in] timestamp Nullable Timestamp of the message.
  * @param[in] qos Quality of service for MQTT publish.
- * @return ASTARTE_OK if publish has been successful, an error code otherwise.
+ * @return ASTARTE_OK if successful, otherwise an error code.
  */
-astarte_err_t publish_bson(astarte_device_handle_t device, const char *interface_name,
-    const char *path, bson_serializer_handle_t bson, int qos);
+astarte_err_t astarte_device_stream_individual(astarte_device_handle_t device, char *interface_name,
+    char *path, astarte_value_t value, const int64_t *timestamp, uint8_t qos);
 
 #ifdef __cplusplus
 }

--- a/include/astarte_device_sdk/type.h
+++ b/include/astarte_device_sdk/type.h
@@ -1,0 +1,282 @@
+/*
+ * (C) Copyright 2024, SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ASTARTE_DEVICE_SDK_TYPE_H
+#define ASTARTE_DEVICE_SDK_TYPE_H
+
+/**
+ * @file type.h
+ * @brief Astarte supported types definitions
+ */
+
+/**
+ * @defgroup types Astarte types
+ * @ingroup astarte_device_sdk
+ * @{
+ */
+
+#include "astarte_device_sdk/astarte.h"
+#include "astarte_device_sdk/bson_serializer.h"
+#include "astarte_device_sdk/error.h"
+#include "astarte_device_sdk/util.h"
+
+/**
+ * @brief mapping type
+ *
+ * This enum represents the possible types of an
+ * [Astarte interface
+ * mapping](https://docs.astarte-platform.org/astarte/latest/040-interface_schema.html#astarte-mapping-schema-type)
+ */
+typedef enum
+{
+    /** @brief Astarte integer type */
+    TYPE_INTEGER = 1,
+    /** @brief Astarte longinteger type */
+    TYPE_LONGINTEGER = 2,
+    /** @brief Astarte double type */
+    TYPE_DOUBLE = 3,
+    /** @brief Astarte string type */
+    TYPE_STRING = 4,
+    /** @brief Astarte binaryblob type */
+    TYPE_BINARYBLOB = 5,
+    /** @brief Astarte boolean type */
+    TYPE_BOOLEAN = 6,
+    /** @brief Astarte datetime type */
+    TYPE_DATETIME = 7,
+
+    /** @brief Astarte integerarray type */
+    TYPE_INTEGERARRAY = 8,
+    /** @brief Astarte longintegerarray type */
+    TYPE_LONGINTEGERARRAY = 9,
+    /** @brief Astarte doublearray type */
+    TYPE_DOUBLEARRAY = 10,
+    /** @brief Astarte stringarray type */
+    TYPE_STRINGARRAY = 11,
+    /** @brief Astarte binaryblobarray type */
+    TYPE_BINARYBLOBARRAY = 12,
+    /** @brief Astarte booleanarray type */
+    TYPE_BOOLEANARRAY = 13,
+    /** @brief Astarte datetimearray type */
+    TYPE_DATETIMEARRAY = 14,
+} astarte_type_t;
+
+/** @brief Container for a binary blob type */
+ASTARTE_UTIL_DEFINE_ARRAY(astarte_binaryblob_t, void);
+/** @brief Integer array type */
+ASTARTE_UTIL_DEFINE_ARRAY(astarte_int32_array_t, int32_t);
+/** @brief Long integer array type */
+ASTARTE_UTIL_DEFINE_ARRAY(astarte_int64_array_t, int64_t);
+/** @brief Double array type */
+ASTARTE_UTIL_DEFINE_ARRAY(astarte_double_array_t, double);
+/** @brief String array type */
+ASTARTE_UTIL_DEFINE_ARRAY(astarte_string_array_t, const char *const);
+/** @brief Bool array type */
+ASTARTE_UTIL_DEFINE_ARRAY(astarte_bool_array_t, bool);
+
+// TODO use the ASTARTE_UTIL_DEFINE_ARRAY macro to also generate astarte_binary_arrays_t
+// and refactor bson_serializer_append_binary_array to accept the array as input
+/** @brief Astarte binary arrays type */
+typedef struct
+{
+    /** @brief Array of binary blobs */
+    const void *const *blobs;
+    /** @brief Array of sizes of each binary blobs */
+    const int *sizes;
+    /** @brief Number of elements in both array blobs and sizes */
+    size_t count;
+} astarte_binary_arrays_t;
+
+/** @brief Union grouping all the containers for Astarte types */
+typedef union
+{
+    /** @brief Union variant associated with tag #TYPE_INTEGER */
+    int32_t integer;
+    /** @brief Union variant associated with tag #TYPE_LONGINTEGER */
+    int64_t longinteger;
+    /** @brief Union variant associated with tag #TYPE_DOUBLE */
+    double dbl;
+    /** @brief Union variant associated with tag #TYPE_STRING */
+    const char *string;
+    /** @brief Union variant associated with tag #TYPE_BINARYBLOB */
+    astarte_binaryblob_t binaryblob;
+    /** @brief Union variant associated with tag #TYPE_BOOLEAN */
+    bool boolean;
+    /** @brief Union variant associated with tag #TYPE_DATETIME */
+    int64_t datetime;
+
+    /** @brief Union variant associated with tag #TYPE_INTEGERARRAY */
+    astarte_int32_array_t integer_array;
+    /** @brief Union variant associated with tag #TYPE_LONGINTEGERARRAY */
+    astarte_int64_array_t longinteger_array;
+    /** @brief Union variant associated with tag #TYPE_DOUBLEARRAY */
+    astarte_double_array_t double_array;
+    /** @brief Union variant associated with tag #TYPE_STRINGARRAY */
+    astarte_string_array_t string_array;
+    /** @brief Union variant associated with tag #TYPE_BINARYBLOBARRAY */
+    astarte_binary_arrays_t binaryblob_array;
+    /** @brief Union variant associated with tag #TYPE_BOOLEANARRAY */
+    astarte_bool_array_t boolean_array;
+    /** @brief Union variant associated with tag #TYPE_DATETIMEARRAY */
+    astarte_int64_array_t datetime_array;
+} astarte_type_param_t;
+
+/**
+ * @brief Value type
+ *
+ * @details This struct is a tagged enum and represents every possible type that can be sent to
+ * astarte. This struct should be initialized only by using one of the defined
+ * `astarte_value_from_*` methods.
+ *
+ * See the following initialization methods:
+ *  - #astarte_value_from_integer
+ *  - #astarte_value_from_longinteger
+ *  - #astarte_value_from_double
+ *  - #astarte_value_from_string
+ *  - #astarte_value_from_binaryblob
+ *  - #astarte_value_from_boolean
+ *  - #astarte_value_from_datetime
+ *  - #astarte_value_from_integer_array
+ *  - #astarte_value_from_longinteger_array
+ *  - #astarte_value_from_double_array
+ *  - #astarte_value_from_string_array
+ *  - #astarte_value_from_binaryblob_array
+ *  - #astarte_value_from_boolean_array
+ *  - #astarte_value_from_datetime_array
+ */
+typedef struct
+{
+    /** @brief Value of the tagged enum */
+    astarte_type_param_t value;
+    /** @brief Tag of the tagged enum */
+    astarte_type_t tag;
+} astarte_value_t;
+
+/**
+ * @brief Serializes the passed #astarte_value_t to the passed #bson_serializer_handle_t
+ *
+ * @param[in,out] bson a valid handle for the serializer instance.
+ * @param[in] key BSON key name, which is a C string.
+ * @param[in] value the #astarte_value_t to serialize to the bson.
+ * @return ASTARTE_OK if successful, otherwise an error code.
+ */
+astarte_err_t astarte_value_serialize(
+    bson_serializer_handle_t bson, char *key, astarte_value_t value);
+
+/**
+ * @brief Initialize an astarte value from the passed integer.
+ *
+ * @param[in] integer value that will be wrapped in the astarte value.
+ * @return The astarte value that wraps an integer with type tag TYPE_INTEGER.
+ */
+astarte_value_t astarte_value_from_integer(int32_t integer);
+/**
+ * @brief Initialize an astarte value from the passed longinteger.
+ *
+ * @param[in] longinteger value that will be wrapped in the astarte value.
+ * @return The astarte value that wraps a longinteger with type tag TYPE_LONGINTEGER.
+ */
+astarte_value_t astarte_value_from_longinteger(int64_t longinteger);
+/**
+ * @brief Initialize an astarte value from the passed double.
+ *
+ * @param[in] dbl value that will be wrapped in the astarte value.
+ * @return The astarte value that wraps a double with type tag TYPE_DOUBLE.
+ */
+astarte_value_t astarte_value_from_double(double dbl);
+/**
+ * @brief Initialize an astarte value from the passed string.
+ *
+ * @param[in] string value that will be wrapped in the astarte value.
+ * @return The astarte value that wraps a string with type tag TYPE_STRING.
+ */
+astarte_value_t astarte_value_from_string(const char *string);
+/**
+ * @brief Initialize an astarte value from the passed binaryblob.
+ *
+ * @param[in] binaryblob value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps a binaryblob with type tag TYPE_BINARYBLOB.
+ */
+astarte_value_t astarte_value_from_binaryblob(void *binaryblob, size_t len);
+/**
+ * @brief Initialize an astarte value from the passed boolean.
+ *
+ * @param[in] boolean value that will be wrapped in the astarte value.
+ * @return The astarte value that wraps a boolean with type tag TYPE_BOOLEAN.
+ */
+astarte_value_t astarte_value_from_boolean(bool boolean);
+/**
+ * @brief Initialize an astarte value from the passed datetime.
+ *
+ * @param[in] datetime value that will be wrapped in the astarte value.
+ * @return The astarte value that wraps a datetime with type tag TYPE_DATETIME.
+ */
+astarte_value_t astarte_value_from_datetime(int64_t datetime);
+
+/**
+ * @brief Initialize an astarte value from the passed integer_array.
+ *
+ * @param[in] integer_array value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps an integer_array with type tag TYPE_INTEGERARRAY.
+ */
+astarte_value_t astarte_value_from_integer_array(int32_t *integer_array, size_t len);
+/**
+ * @brief Initialize an astarte value from the passed longinteger_array.
+ *
+ * @param[in] longinteger_array value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps a longinteger_array with type tag TYPE_LONGINTEGERARRAY.
+ */
+astarte_value_t astarte_value_from_longinteger_array(int64_t *longinteger_array, size_t len);
+/**
+ * @brief Initialize an astarte value from the passed double_array.
+ *
+ * @param[in] double_array value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps a double_array with type tag TYPE_DOUBLEARRAY.
+ */
+astarte_value_t astarte_value_from_double_array(double *double_array, size_t len);
+/**
+ * @brief Initialize an astarte value from the passed string_array.
+ *
+ * @param[in] string_array value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps a string_array with type tag TYPE_STRINGARRAY.
+ */
+astarte_value_t astarte_value_from_string_array(const char *const *string_array, size_t len);
+/**
+ * @brief Initialize an astarte value from the passed string_array.
+ *
+ * @param[in] buf Stores a list of buffers, the i-th buffer is of size size[i].
+ * @param[in] sizes Sizes of each of the buffer stored in buf.
+ * @param[in] count Number of elements in both buf and sizes.
+ * @return The astarte value that wraps a binary_array with type tag TYPE_BINARYBLOBARRAY.
+ */
+astarte_value_t astarte_value_from_binaryblob_array(
+    const void *const *buf, const int *sizes, size_t count);
+/**
+ * @brief Initialize an astarte value from the passed boolean_array.
+ *
+ * @param[in] boolean_array value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps a boolean_array with type tag TYPE_BOOLEANARRAY.
+ */
+astarte_value_t astarte_value_from_boolean_array(bool *boolean_array, size_t len);
+/**
+ * @brief Initialize an astarte value from the passed datetime_array.
+ *
+ * @param[in] datetime_array value that will be wrapped in the astarte value.
+ * @param[in] len The length of the passed array.
+ * @return The astarte value that wraps a datetime_array with type tag TYPE_DATETIMEARRAY.
+ */
+astarte_value_t astarte_value_from_datetime_array(int64_t *datetime_array, size_t len);
+
+/**
+ * @}
+ */
+
+#endif /* ASTARTE_DEVICE_SDK_TYPE_H */

--- a/include/astarte_device_sdk/util.h
+++ b/include/astarte_device_sdk/util.h
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright 2024, SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file util.h
+ * @brief Utility macros and functions
+ */
+
+#ifndef ASTARTE_DEVICE_SDK_UTIL_H
+#define ASTARTE_DEVICE_SDK_UTIL_H
+
+/**
+ * @ingroup utils
+ * @{
+ */
+
+/**
+ * @brief Define a struct that contains a pointer of type TYPE and a length
+ * @param[in] NAME name of the type
+ * @param[in] TYPE type of an element of the array.
+ */
+// NOLINTBEGIN(bugprone-macro-parentheses) TYPE parameter can't be enclosed in parenthesis.
+#define ASTARTE_UTIL_DEFINE_ARRAY(NAME, TYPE)                                                      \
+    typedef struct                                                                                 \
+    {                                                                                              \
+        TYPE *buf;                                                                                 \
+        size_t len;                                                                                \
+    } NAME;
+// NOLINTEND(bugprone-macro-parentheses)
+
+/**
+ * @}
+ */
+#endif /* ASTARTE_DEVICE_SDK_UTIL_H */

--- a/lib/astarte_device_sdk/type.c
+++ b/lib/astarte_device_sdk/type.c
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright 2024, SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "astarte_device_sdk/type.h"
+
+#include "astarte_device_sdk/bson_serializer.h"
+#include "astarte_device_sdk/error.h"
+
+astarte_err_t astarte_value_serialize(
+    bson_serializer_handle_t bson, char *key, astarte_value_t value)
+{
+    astarte_err_t ret = ASTARTE_OK;
+
+    switch (value.tag) {
+        case TYPE_INTEGER:
+            bson_serializer_append_int32(bson, key, value.value.integer);
+            break;
+        case TYPE_LONGINTEGER:
+            bson_serializer_append_int64(bson, key, value.value.longinteger);
+            break;
+        case TYPE_DOUBLE:
+            bson_serializer_append_double(bson, key, value.value.dbl);
+            break;
+        case TYPE_STRING:
+            bson_serializer_append_string(bson, key, value.value.string);
+            break;
+        case TYPE_BINARYBLOB: {
+            astarte_binaryblob_t binaryblob = value.value.binaryblob;
+            bson_serializer_append_binary(bson, key, binaryblob.buf, binaryblob.len);
+            break;
+        }
+        case TYPE_BOOLEAN:
+            bson_serializer_append_boolean(bson, key, value.value.boolean);
+            break;
+        case TYPE_DATETIME:
+            bson_serializer_append_datetime(bson, key, value.value.datetime);
+            break;
+        case TYPE_INTEGERARRAY: {
+            astarte_int32_array_t int32_array = value.value.integer_array;
+            ret = bson_serializer_append_int32_array(
+                bson, key, int32_array.buf, (int) int32_array.len);
+            break;
+        }
+        case TYPE_LONGINTEGERARRAY: {
+            astarte_int64_array_t int64_array = value.value.longinteger_array;
+            ret = bson_serializer_append_int64_array(
+                bson, key, int64_array.buf, (int) int64_array.len);
+            break;
+        }
+        case TYPE_DOUBLEARRAY: {
+            astarte_double_array_t double_array = value.value.double_array;
+            ret = bson_serializer_append_double_array(
+                bson, key, double_array.buf, (int) double_array.len);
+            break;
+        }
+        case TYPE_STRINGARRAY: {
+            astarte_string_array_t string_array = value.value.string_array;
+            ret = bson_serializer_append_string_array(
+                bson, key, string_array.buf, (int) string_array.len);
+            break;
+        }
+        case TYPE_BINARYBLOBARRAY: {
+            astarte_binary_arrays_t binary_arrays = value.value.binaryblob_array;
+            ret = bson_serializer_append_binary_array(
+                bson, key, binary_arrays.blobs, binary_arrays.sizes, (int) binary_arrays.count);
+            break;
+        }
+        case TYPE_BOOLEANARRAY: {
+            astarte_bool_array_t bool_array = value.value.boolean_array;
+            ret = bson_serializer_append_boolean_array(
+                bson, key, bool_array.buf, (int) bool_array.len);
+            break;
+        }
+        case TYPE_DATETIMEARRAY: {
+            astarte_int64_array_t dt_array = value.value.datetime_array;
+            ret = bson_serializer_append_datetime_array(
+                bson, key, dt_array.buf, (int) dt_array.len);
+            break;
+        }
+        default:
+            ret = ASTARTE_ERR_INVALID_PARAM;
+            break;
+    }
+
+    return ret;
+}
+
+// clang-format off
+#define DEFINE_ASTARTE_TYPE_MAKE_FN(NAME, ENUM, TYPE, PARAM)                                       \
+    astarte_value_t astarte_value_from_##NAME(TYPE PARAM)                                          \
+    {                                                                                              \
+        return (astarte_value_t) {                                                                 \
+            .value = {                                                                             \
+                .PARAM = (PARAM),                                                                  \
+            },                                                                                     \
+            .tag = (ENUM),                                                                         \
+        };                                                                                         \
+    }
+
+#define DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(NAME, ENUM, TYPE, PARAM)                                 \
+    astarte_value_t astarte_value_from_##NAME(TYPE PARAM, size_t len)                              \
+    {                                                                                              \
+        return (astarte_value_t) {                                                                 \
+            .value = {                                                                             \
+                .PARAM = {                                                                         \
+                    .buf = (PARAM),                                                                \
+                    .len = len,                                                                    \
+                },                                                                                 \
+            },                                                                                     \
+            .tag = (ENUM),                                                                         \
+        };                                                                                         \
+    }
+// clang-format on
+
+DEFINE_ASTARTE_TYPE_MAKE_FN(integer, TYPE_INTEGER, int32_t, integer)
+DEFINE_ASTARTE_TYPE_MAKE_FN(longinteger, TYPE_LONGINTEGER, int64_t, longinteger)
+DEFINE_ASTARTE_TYPE_MAKE_FN(double, TYPE_DOUBLE, double, dbl)
+DEFINE_ASTARTE_TYPE_MAKE_FN(string, TYPE_STRING, const char *, string)
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(binaryblob, TYPE_BINARYBLOB, void *, binaryblob)
+DEFINE_ASTARTE_TYPE_MAKE_FN(boolean, TYPE_BOOLEAN, bool, boolean)
+DEFINE_ASTARTE_TYPE_MAKE_FN(datetime, TYPE_DATETIME, int64_t, datetime)
+
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(integer_array, TYPE_INTEGERARRAY, int32_t *, integer_array)
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(
+    longinteger_array, TYPE_LONGINTEGERARRAY, int64_t *, longinteger_array)
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(double_array, TYPE_DOUBLEARRAY, double *, double_array)
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(string_array, TYPE_STRINGARRAY, const char *const *, string_array)
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(boolean_array, TYPE_BOOLEANARRAY, bool *, boolean_array)
+DEFINE_ASTARTE_ARRAY_TYPE_MAKE_FN(datetime_array, TYPE_DATETIMEARRAY, int64_t *, datetime_array)
+
+astarte_value_t astarte_value_from_binaryblob_array(
+    const void *const *buf, const int *sizes, size_t count)
+{
+    return (astarte_value_t) {
+        .value = {
+            .binaryblob_array = {
+                .blobs = buf,
+                .sizes = sizes,
+                .count = count,
+            },
+        },
+        .tag = TYPE_BINARYBLOBARRAY,
+    };
+}

--- a/samples/datastreams/src/main.c
+++ b/samples/datastreams/src/main.c
@@ -25,6 +25,7 @@ LOG_MODULE_REGISTER(main, CONFIG_APP_LOG_LEVEL); // NOLINT
 #include <astarte_device_sdk/device.h>
 #include <astarte_device_sdk/interface.h>
 #include <astarte_device_sdk/pairing.h>
+#include <astarte_device_sdk/type.h>
 
 #include "wifi.h"
 
@@ -194,15 +195,13 @@ static void astarte_data_events_handler(astarte_device_data_event_t *event)
         && strcmp(event->path, "/boolean_endpoint") == 0
         && event->bson_element.type == BSON_TYPE_BOOLEAN) {
         bool answer = !bson_deserializer_element_to_bool(event->bson_element);
+        astarte_value_t astarte_answer = astarte_value_from_boolean(answer);
         LOG_INF("Sending answer %d.", answer); // NOLINT
 
-        bson_serializer_handle_t bson = bson_serializer_new();
-        bson_serializer_append_boolean(bson, "v", answer);
-        bson_serializer_append_end_of_document(bson);
-
         int qos = 0;
-        astarte_err_t res = publish_bson(event->device,
-            "org.astarteplatform.zephyr.examples.DeviceDatastream", "/boolean_endpoint", bson, qos);
+        astarte_err_t res = astarte_device_stream_individual(event->device,
+            "org.astarteplatform.zephyr.examples.DeviceDatastream", "/boolean_endpoint",
+            astarte_answer, NULL, qos);
         if (res != ASTARTE_OK) {
             LOG_INF("Failue sending answer %d.", answer); // NOLINT
         }

--- a/tests/lib/astarte_device_sdk/unit/type/CMakeLists.txt
+++ b/tests/lib/astarte_device_sdk/unit/type/CMakeLists.txt
@@ -1,0 +1,15 @@
+# (C) Copyright 2024, SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(astarte_device_sdk_unit_type)
+
+target_include_directories(testbinary PRIVATE
+    ${ZEPHYR_BASE}/../astarte-device-sdk-zephyr/include
+    ${ZEPHYR_BASE}/../astarte-device-sdk-zephyr
+)
+
+FILE(GLOB test_sources src/*.c)
+target_sources(testbinary PRIVATE ${test_sources})

--- a/tests/lib/astarte_device_sdk/unit/type/prj.conf
+++ b/tests/lib/astarte_device_sdk/unit/type/prj.conf
@@ -1,0 +1,5 @@
+# (C) Copyright 2024, SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y

--- a/tests/lib/astarte_device_sdk/unit/type/src/main.c
+++ b/tests/lib/astarte_device_sdk/unit/type/src/main.c
@@ -1,0 +1,411 @@
+/*
+ * (C) Copyright 2024, SECO Mind Srl
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * @file astarte-device-sdk-zephyr/tests/lib/astarte_device_sdk/unit/bson/src/main.c
+ *
+ * @details This test suite verifies that the methods provided with the bson
+ * module works correctly.
+ *
+ * @note This should be run with the latest version of zephyr present on master (or 3.6.0)
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include <zephyr/ztest.h>
+
+#include "astarte_device_sdk/bson_serializer.h"
+#include "astarte_device_sdk/type.h"
+#include "lib/astarte_device_sdk/bson_serializer.c"
+#include "lib/astarte_device_sdk/type.c"
+
+ZTEST_SUITE(astarte_device_sdk_type, NULL, NULL, NULL, NULL, NULL);
+
+// Define a minimal_log function to resolve the `undefined reference to z_log_minimal_printk` error,
+// because the log environment is missing in the unit_testing platform.
+void z_log_minimal_printk(const char *fmt, ...) {}
+
+static void compare_buf(uint8_t *val_a, uint8_t *val_b, size_t len)
+{
+    for (size_t i = 0; i < len; ++i) {
+        zassert_equal(val_a[i], val_b[i]);
+    }
+}
+
+static void print_hex(const char *s, size_t len)
+{
+    for (int i = 0; i < len; ++i) {
+        printf("%02x", (unsigned int) *s++);
+    }
+
+    printf("\n");
+}
+
+#define TEST_SINGLE_PROPERTY_SERIALIZATION(METHOD, VALUE, SERIALIZED_CONST)                        \
+    ZTEST(astarte_device_sdk_type, test_serialize_##METHOD)                                        \
+    {                                                                                              \
+        astarte_value_t astarte_value = astarte_value_from_##METHOD(VALUE);                        \
+        bson_serializer_handle_t bson = bson_serializer_new();                                     \
+        astarte_value_serialize(bson, "v", astarte_value);                                         \
+        bson_serializer_append_end_of_document(bson);                                              \
+        int len = 0;                                                                               \
+        const void *data = bson_serializer_get_document(bson, &len);                               \
+        print_hex(data, (size_t) len);                                                             \
+        zassert_equal(len, sizeof(SERIALIZED_CONST));                                              \
+        compare_buf((uint8_t *) data, (uint8_t *) (SERIALIZED_CONST), (size_t) len);               \
+    }
+
+const int32_t test_integer = 42;
+const uint8_t serialized_integer[] = {
+    0x0C,
+    0x00,
+    0x00,
+    0x00,
+    0x10,
+    0x76,
+    0x00,
+    0x2a,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+};
+TEST_SINGLE_PROPERTY_SERIALIZATION(integer, test_integer, serialized_integer) // NOLINT
+
+const int64_t test_longinteger = 3147483647;
+const uint8_t serialized_longinteger[] = {
+    0x10,
+    0x00,
+    0x00,
+    0x00,
+    0x12,
+    0x76,
+    0x00,
+    0xff,
+    0xc9,
+    0x9a,
+    0xbb,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+};
+TEST_SINGLE_PROPERTY_SERIALIZATION(longinteger, test_longinteger, serialized_longinteger) // NOLINT
+
+const double test_double = 432.4324;
+const uint8_t serialized_double[] = { 0x10, 0x00, 0x00, 0x00, 0x01, 0x76, 0x00, 0xa5, 0x2c, 0x43,
+    0x1c, 0xeb, 0x06, 0x7b, 0x40, 0x00 };
+TEST_SINGLE_PROPERTY_SERIALIZATION(double, test_double, serialized_double) // NOLINT
+
+const bool test_boolean = true;
+const uint8_t serialized_boolean[] = {
+    0x09,
+    0x00,
+    0x00,
+    0x00,
+    0x08,
+    0x76,
+    0x00,
+    0x01,
+    0x00,
+};
+TEST_SINGLE_PROPERTY_SERIALIZATION(boolean, test_boolean, serialized_boolean) // NOLINT
+
+const char *test_string = "this is a test string";
+const uint8_t serialized_string[] = {
+    0x22,
+    0x00,
+    0x00,
+    0x00,
+    0x02,
+    0x76,
+    0x00,
+    0x16,
+    0x00,
+    0x00,
+    0x00,
+    0x74,
+    0x68,
+    0x69,
+    0x73,
+    0x20,
+    0x69,
+    0x73,
+    0x20,
+    0x61,
+    0x20,
+    0x74,
+    0x65,
+    0x73,
+    0x74,
+    0x20,
+    0x73,
+    0x74,
+    0x72,
+    0x69,
+    0x6e,
+    0x67,
+    0x00,
+    0x00,
+};
+TEST_SINGLE_PROPERTY_SERIALIZATION(string, test_string, serialized_string) // NOLINT
+
+#define TEST_ARRAY_SERIALIZATION(METHOD, ARRAY_ELEMENT_TYPE, ARRAY_CONST, SERIALIZED_CONST)        \
+    ZTEST(astarte_device_sdk_type, test_serialize_##METHOD)                                        \
+    {                                                                                              \
+        astarte_value_t astarte_value                                                              \
+            = astarte_value_from_##METHOD((ARRAY_ELEMENT_TYPE *) &(ARRAY_CONST),                   \
+                sizeof(ARRAY_CONST) / sizeof(ARRAY_ELEMENT_TYPE));                                 \
+        bson_serializer_handle_t bson = bson_serializer_new();                                     \
+        astarte_value_serialize(bson, "v", astarte_value);                                         \
+        bson_serializer_append_end_of_document(bson);                                              \
+        int len = 0;                                                                               \
+        const void *data = bson_serializer_get_document(bson, &len);                               \
+        print_hex(data, (size_t) len);                                                             \
+        zassert_equal(len, sizeof(SERIALIZED_CONST));                                              \
+        compare_buf((uint8_t *) data, (uint8_t *) (SERIALIZED_CONST), (size_t) len);               \
+    }
+
+const int32_t test_integer_array[] = {
+    42,
+    10,
+    128,
+    9,
+    256,
+};
+const uint8_t serialized_integer_array[] = {
+    0x30,
+    0x00,
+    0x00,
+    0x00,
+    0x04,
+    0x76,
+    0x00,
+    0x28,
+    0x00,
+    0x00,
+    0x00,
+    0x10,
+    0x30,
+    0x00,
+    0x2a,
+    0x00,
+    0x00,
+    0x00,
+    0x10,
+    0x31,
+    0x00,
+    0x0a,
+    0x00,
+    0x00,
+    0x00,
+    0x10,
+    0x32,
+    0x00,
+    0x80,
+    0x00,
+    0x00,
+    0x00,
+    0x10,
+    0x33,
+    0x00,
+    0x09,
+    0x00,
+    0x00,
+    0x00,
+    0x10,
+    0x34,
+    0x00,
+    0x00,
+    0x01,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+};
+TEST_ARRAY_SERIALIZATION(integer_array, int32_t, test_integer_array, serialized_integer_array)
+
+const char *test_string_array[] = { "this", "is", "a", "test", "string_array" };
+const uint8_t serialized_string_array[] = {
+    0x4c,
+    0x00,
+    0x00,
+    0x00,
+    0x04,
+    0x76,
+    0x00,
+    0x44,
+    0x00,
+    0x00,
+    0x00,
+    0x02,
+    0x30,
+    0x00,
+    0x05,
+    0x00,
+    0x00,
+    0x00,
+    0x74,
+    0x68,
+    0x69,
+    0x73,
+    0x00,
+    0x02,
+    0x31,
+    0x00,
+    0x03,
+    0x00,
+    0x00,
+    0x00,
+    0x69,
+    0x73,
+    0x00,
+    0x02,
+    0x32,
+    0x00,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x61,
+    0x00,
+    0x02,
+    0x33,
+    0x00,
+    0x05,
+    0x00,
+    0x00,
+    0x00,
+    0x74,
+    0x65,
+    0x73,
+    0x74,
+    0x00,
+    0x02,
+    0x34,
+    0x00,
+    0x0d,
+    0x00,
+    0x00,
+    0x00,
+    0x73,
+    0x74,
+    0x72,
+    0x69,
+    0x6e,
+    0x67,
+    0x5f,
+    0x61,
+    0x72,
+    0x72,
+    0x61,
+    0x79,
+    0x00,
+    0x00,
+    0x00,
+};
+TEST_ARRAY_SERIALIZATION(
+    string_array, const char *const, test_string_array, serialized_string_array)
+
+const uint8_t blob_1[] = {
+    0x41,
+    0x53,
+    0x54,
+    0x41,
+    0x52,
+    0x54,
+    0x45,
+};
+const uint8_t blob_2[] = {
+    0x49,
+    0x53,
+};
+const uint8_t blob_3[] = {
+    0x43,
+    0x4F,
+    0x4F,
+    0x4C,
+};
+const void *test_binaryblob_array[] = {
+    blob_1,
+    blob_2,
+    blob_3,
+};
+const int test_binaryblob_sizes[] = {
+    sizeof(blob_1) / sizeof(uint8_t),
+    sizeof(blob_2) / sizeof(uint8_t),
+    sizeof(blob_3) / sizeof(uint8_t),
+};
+const uint8_t serialized_binaryblob_array[] = {
+    0x32,
+    0x00,
+    0x00,
+    0x00,
+    0x04,
+    0x76,
+    0x00,
+    0x2a,
+    0x00,
+    0x00,
+    0x00,
+    0x05,
+    0x30,
+    0x00,
+    0x07,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x41,
+    0x53,
+    0x54,
+    0x41,
+    0x52,
+    0x54,
+    0x45,
+    0x05,
+    0x31,
+    0x00,
+    0x02,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x49,
+    0x53,
+    0x05,
+    0x32,
+    0x00,
+    0x04,
+    0x00,
+    0x00,
+    0x00,
+    0x00,
+    0x43,
+    0x4f,
+    0x4f,
+    0x4c,
+    0x00,
+    0x00,
+};
+ZTEST(astarte_device_sdk_type, test_serialize_binaryblob_array)
+{
+    astarte_value_t astarte_value = astarte_value_from_binaryblob_array(test_binaryblob_array,
+        test_binaryblob_sizes, sizeof(test_binaryblob_array) / sizeof(uint8_t *));
+
+    bson_serializer_handle_t bson = bson_serializer_new();
+    astarte_value_serialize(bson, "v", astarte_value);
+    bson_serializer_append_end_of_document(bson);
+    int len = 0;
+    const void *data = bson_serializer_get_document(bson, &len);
+
+    print_hex(data, len);
+    zassert_equal(len, sizeof(serialized_binaryblob_array));
+    compare_buf((uint8_t *) data, (uint8_t *) serialized_binaryblob_array, (size_t) len);
+}

--- a/tests/lib/astarte_device_sdk/unit/type/testcase.yaml
+++ b/tests/lib/astarte_device_sdk/unit/type/testcase.yaml
@@ -1,0 +1,8 @@
+# (C) Copyright 2024, SECO Mind Srl
+#
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  lib.astarte_device_sdk.unit.type:
+    tags: astarte_device_sdk
+    type: unit


### PR DESCRIPTION
Added a new method to stream individual generic data by using the tagged union `astarte_value_t`.
Closes #13, closes #6.