### PR TITLE
Fix formatting of generated files and change generation

### DIFF
--- a/samples/common/interfaces/generated_interfaces.c
+++ b/samples/common/interfaces/generated_interfaces.c
@@ -18,7 +18,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_DOUBLE,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/integer_endpoint",
@@ -26,7 +26,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_INTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/boolean_endpoint",
@@ -34,7 +34,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_BOOLEAN,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/longinteger_endpoint",
@@ -42,7 +42,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/string_endpoint",
@@ -50,7 +50,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_STRING,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblob_endpoint",
@@ -58,7 +58,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOB,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/datetime_endpoint",
@@ -66,7 +66,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_DATETIME,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/doublearray_endpoint",
@@ -74,7 +74,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_DOUBLEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/integerarray_endpoint",
@@ -82,7 +82,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_INTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/booleanarray_endpoint",
@@ -90,7 +90,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_BOOLEANARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/longintegerarray_endpoint",
@@ -98,7 +98,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/stringarray_endpoint",
@@ -106,7 +106,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_STRINGARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblobarray_endpoint",
@@ -114,7 +114,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOBARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/datetimearray_endpoint",
@@ -122,7 +122,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceAggrega
         .type = ASTARTE_MAPPING_TYPE_DATETIMEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
 };
 
@@ -145,7 +145,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOB,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/binaryblobarray_endpoint",
@@ -153,7 +153,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOBARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/boolean_endpoint",
@@ -161,7 +161,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_BOOLEAN,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/booleanarray_endpoint",
@@ -169,7 +169,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_BOOLEANARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/datetime_endpoint",
@@ -177,7 +177,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_DATETIME,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/datetimearray_endpoint",
@@ -185,7 +185,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_DATETIMEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/double_endpoint",
@@ -193,7 +193,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_DOUBLE,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/doublearray_endpoint",
@@ -201,7 +201,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_DOUBLEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/integer_endpoint",
@@ -209,7 +209,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_INTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/integerarray_endpoint",
@@ -217,7 +217,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_INTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/longinteger_endpoint",
@@ -225,7 +225,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/longintegerarray_endpoint",
@@ -233,7 +233,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/string_endpoint",
@@ -241,7 +241,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_STRING,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/stringarray_endpoint",
@@ -249,7 +249,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DeviceDatastr
         .type = ASTARTE_MAPPING_TYPE_STRINGARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = true,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
 };
 
@@ -272,7 +272,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_DOUBLE,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/integer_endpoint",
@@ -280,7 +280,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_INTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/boolean_endpoint",
@@ -288,7 +288,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_BOOLEAN,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/longinteger_endpoint",
@@ -296,7 +296,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/string_endpoint",
@@ -304,7 +304,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_STRING,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblob_endpoint",
@@ -312,7 +312,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOB,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/datetime_endpoint",
@@ -320,7 +320,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_DATETIME,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/doublearray_endpoint",
@@ -328,7 +328,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_DOUBLEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/integerarray_endpoint",
@@ -336,7 +336,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_INTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/booleanarray_endpoint",
@@ -344,7 +344,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_BOOLEANARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/longintegerarray_endpoint",
@@ -352,7 +352,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/stringarray_endpoint",
@@ -360,7 +360,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_STRINGARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblobarray_endpoint",
@@ -368,7 +368,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOBARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/datetimearray_endpoint",
@@ -376,7 +376,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_DevicePropert
         .type = ASTARTE_MAPPING_TYPE_DATETIMEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
 };
 
@@ -399,7 +399,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_DOUBLE,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/integer_endpoint",
@@ -407,7 +407,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_INTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/boolean_endpoint",
@@ -415,7 +415,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_BOOLEAN,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/longinteger_endpoint",
@@ -423,7 +423,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/string_endpoint",
@@ -431,7 +431,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_STRING,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblob_endpoint",
@@ -439,7 +439,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOB,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/datetime_endpoint",
@@ -447,7 +447,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_DATETIME,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/doublearray_endpoint",
@@ -455,7 +455,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_DOUBLEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/integerarray_endpoint",
@@ -463,7 +463,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_INTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/booleanarray_endpoint",
@@ -471,7 +471,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_BOOLEANARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/longintegerarray_endpoint",
@@ -479,7 +479,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/stringarray_endpoint",
@@ -487,7 +487,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_STRINGARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblobarray_endpoint",
@@ -495,7 +495,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOBARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/%{sensor_id}/datetimearray_endpoint",
@@ -503,7 +503,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerAggrega
         .type = ASTARTE_MAPPING_TYPE_DATETIMEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
 };
 
@@ -526,7 +526,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOB,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/binaryblobarray_endpoint",
@@ -534,7 +534,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOBARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/boolean_endpoint",
@@ -542,7 +542,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_BOOLEAN,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/booleanarray_endpoint",
@@ -550,7 +550,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_BOOLEANARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/datetime_endpoint",
@@ -558,7 +558,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_DATETIME,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/datetimearray_endpoint",
@@ -566,7 +566,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_DATETIMEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/double_endpoint",
@@ -574,7 +574,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_DOUBLE,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/doublearray_endpoint",
@@ -582,7 +582,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_DOUBLEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/integer_endpoint",
@@ -590,7 +590,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_INTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/integerarray_endpoint",
@@ -598,7 +598,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_INTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/longinteger_endpoint",
@@ -606,7 +606,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/longintegerarray_endpoint",
@@ -614,7 +614,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/string_endpoint",
@@ -622,7 +622,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_STRING,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
     {
         .endpoint = "/stringarray_endpoint",
@@ -630,7 +630,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerDatastr
         .type = ASTARTE_MAPPING_TYPE_STRINGARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNRELIABLE,
         .explicit_timestamp = false,
-        .allow_unset =  false,
+        .allow_unset = false,
     },
 };
 
@@ -653,7 +653,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_DOUBLE,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/integer_endpoint",
@@ -661,7 +661,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_INTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/boolean_endpoint",
@@ -669,7 +669,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_BOOLEAN,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/longinteger_endpoint",
@@ -677,7 +677,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGER,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/string_endpoint",
@@ -685,7 +685,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_STRING,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblob_endpoint",
@@ -693,7 +693,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOB,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/datetime_endpoint",
@@ -701,7 +701,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_DATETIME,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/doublearray_endpoint",
@@ -709,7 +709,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_DOUBLEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/integerarray_endpoint",
@@ -717,7 +717,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_INTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/booleanarray_endpoint",
@@ -725,7 +725,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_BOOLEANARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/longintegerarray_endpoint",
@@ -733,7 +733,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_LONGINTEGERARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/stringarray_endpoint",
@@ -741,7 +741,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_STRINGARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/binaryblobarray_endpoint",
@@ -749,7 +749,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_BINARYBLOBARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
     {
         .endpoint = "/%{sensor_id}/datetimearray_endpoint",
@@ -757,7 +757,7 @@ static const astarte_mapping_t org_astarteplatform_zephyr_examples_ServerPropert
         .type = ASTARTE_MAPPING_TYPE_DATETIMEARRAY,
         .reliability = ASTARTE_MAPPING_RELIABILITY_UNIQUE,
         .explicit_timestamp = false,
-        .allow_unset =  true,
+        .allow_unset = true,
     },
 };
 


### PR DESCRIPTION
Removed a space from the generation script pattern.
Added a regex to remove whitespaces outside of strings from the checked code.
The last part about removing whitespaces requires attention because the rule is not well defined and it will remove all whitespaces outside of pairs `"` for example in character literal `' '` or other places where whitespaces could be meaningful to c. So I'm not sure whether to include it or not.