### PR TITLE
Move `connection_state` change before notify the connection callback

### DIFF
--- a/lib/astarte_device_sdk/device.c
+++ b/lib/astarte_device_sdk/device.c
@@ -492,6 +492,8 @@ astarte_result_t astarte_device_poll(astarte_device_handle_t device)
         && astarte_mqtt_is_connected(&device->astarte_mqtt)
         && !astarte_mqtt_has_pending_outgoing(&device->astarte_mqtt)) {
 
+        device->connection_state = DEVICE_CONNECTED;
+
         if (device->connection_cbk) {
             astarte_device_connection_event_t event = {
                 .device = device,
@@ -500,7 +502,6 @@ astarte_result_t astarte_device_poll(astarte_device_handle_t device)
 
             device->connection_cbk(event);
         }
-        device->connection_state = DEVICE_CONNECTED;
     }
 
     return astarte_mqtt_poll(&device->astarte_mqtt);


### PR DESCRIPTION
Change the connection_state after calling the callback, introduces out of sync state, because if you try to send data to Astarte, the device is still in the Connecting state, so I first change the state and then notify the callback.