### PR TITLE
No timestamp in doxygen html

### DIFF
--- a/doc/astarte-device-sdk.doxyfile.in
+++ b/doc/astarte-device-sdk.doxyfile.in
@@ -514,7 +514,7 @@ NUM_PROC_THREADS       = 1
 # Possible values are: YES, NO, DATETIME and DATE.
 # The default value is: NO.
 
-TIMESTAMP              = YES
+TIMESTAMP              = NO
 
 #---------------------------------------------------------------------------
 # Build related configuration options

--- a/doc/astarte-device-sdk.extended.doxyfile.in
+++ b/doc/astarte-device-sdk.extended.doxyfile.in
@@ -514,7 +514,7 @@ NUM_PROC_THREADS       = 1
 # Possible values are: YES, NO, DATETIME and DATE.
 # The default value is: NO.
 
-TIMESTAMP              = YES
+TIMESTAMP              = NO
 
 #---------------------------------------------------------------------------
 # Build related configuration options


### PR DESCRIPTION
The generated timestamp would pollute the git diff for identical APIs