### PR TITLE
ci(e2e): Fix e2e not working

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -1,7 +1,7 @@
 #
 # This file is part of Astarte.
 #
-# Copyright 2024 SECO Mind Srl
+# Copyright 2024-2025 SECO Mind Srl
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ env:
   ASTARTE_ACTION_CERT: /usr/local/share/ca-certificates/astarte-autotest.crt
 jobs:
   e2e-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       # setup astarte
       - name: Create Astarte Cluster
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Set up Python dependencies
         working-directory: astarte-device-sdk-zephyr/
@@ -96,6 +96,10 @@ jobs:
           # Write the Astarte certificate
           cat "$ASTARTE_ACTION_CERT" > ./certificate/api-eu1-astarte-cloud.pem
 
+      - name: Install net-setup dependencies
+        run: sudo apt install dnsmasq
+
+      # NOTE this step could silently fail
       - name: Start net-setup nat configuration
         working-directory: tools/net-tools
         run: |
@@ -108,11 +112,13 @@ jobs:
           # add resolution for action astarte dns
           address=/$ASTARTE_API_BASE/$ASTARTE_BROKER_BASE/192.0.2.2
           END
-          sudo ./net-setup.sh start --config nat.conf
+          # Launch net-setup with debugging enabled
+          sudo bash -xuEo pipefail ./net-setup.sh start --config nat.conf
 
       - name: Build and run e2e test zephyr application
-        run: west twister --force-color --ninja -vvv --inline-logs -p native_sim -T ./astarte-device-sdk-zephyr/e2e/
+        run: west twister -vv --force-color --integration --inline-logs -T ./astarte-device-sdk-zephyr/e2e
 
       - name: Stop net-setup nat configuration
         working-directory: tools/net-tools
-        run: sudo ./net-setup.sh stop --config nat.conf
+        run: |
+          sudo bash -xuEo pipefail ./net-setup.sh stop --config nat.conf

--- a/e2e/pytest/interface_data.py
+++ b/e2e/pytest/interface_data.py
@@ -60,7 +60,7 @@ class InterfaceData(ABC):
 
         if self.ownership == Ownership.SERVER:
             helper.exec_commands(self._get_device_shell_commands(EXPECT_BASE_COMMAND))
-            time.sleep(2)
+            time.sleep(1)
             # TODO should also test that the command gets executed and chec the presense of the confirmation string like "Property set"
             self._send_server_data(helper)
             # TODO Could add a command that waits for all message to be sent ?
@@ -70,15 +70,14 @@ class InterfaceData(ABC):
         else:
             send_start = datetime.now(tz=timezone.utc)
             helper.exec_commands(self._get_device_shell_commands(SEND_BASE_COMMAND))
-            time.sleep(2)
 
-            # retry two times
-            for i in range(0, 2):
+            # retry ten times
+            for _ in range(0, 10):
+                time.sleep(1)
+
                 try:
                     self._check_server_received_data(helper, send_start)
                 except (KeyError, ValueError) as e:
-                    log.inf(f"Missing key in server data {e}, retrying...")
-
-                time.sleep(2)
+                    log.inf(f"Missing server data {e}, retrying...")
 
             self._check_server_received_data(helper, send_start)

--- a/e2e/pytest/interface_data_aggregate.py
+++ b/e2e/pytest/interface_data_aggregate.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from west import log

--- a/e2e/pytest/pyproject.toml
+++ b/e2e/pytest/pyproject.toml
@@ -2,6 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-[pytest]
+[tool.pytest.ini_options]
 log_cli = true
 log_cli_level = "DEBUG"
+log_cli_format = "%(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"
+log_cli_date_format = "%Y-%m-%d %H:%M:%S"
+addopts = "-vvv -rA --capture=no --color=yes"

--- a/e2e/testcase.yaml
+++ b/e2e/testcase.yaml
@@ -1,25 +1,18 @@
-# (C) Copyright 2024, SECO Mind Srl
+# (C) Copyright 2024-2025, SECO Mind Srl
 #
 # SPDX-License-Identifier: Apache-2.0
 
 tests:
-  lib.astarte_device_sdk.e2e:
+  astarte_device_sdk.e2e:
     filter: CONFIG_SERIAL and dt_chosen_enabled("zephyr,shell-uart")
     harness: pytest
     extra_configs:
       - arch:posix:CONFIG_NATIVE_UART_0_ON_STDINOUT=y
     harness_config:
       pytest_dut_scope: "session"
-      record:
-        regex: "\\[(?P<timestamp>.*)\\] \\<(?P<log_level>.*)\\> (?P<module>.*)\\: (?P<message>.*)"
-      pytest_args:
-        - "--color=yes"
-        - "-rA"
-        - "-vvv"
-    platform_allow:
-      - native_sim
-    integration_platforms:
-      - native_sim
+    timeout: 300
+    platform_allow: [native_sim]
+    integration_platforms: [native_sim]
     tags:
       - e2e
       - pytest

--- a/lib/astarte_device_sdk/http.c
+++ b/lib/astarte_device_sdk/http.c
@@ -228,7 +228,7 @@ static int create_and_connect_socket(void)
         ASTARTE_LOG_ERR("Unable to resolve address (%d) %s", getaddrinfo_rc,
             zsock_gai_strerror(getaddrinfo_rc));
         if (getaddrinfo_rc == DNS_EAI_SYSTEM) {
-            ASTARTE_LOG_ERR("Errno: %s", strerror(errno));
+            ASTARTE_LOG_ERR("Errno: (%d) %s", errno, strerror(errno));
         }
         return -1;
     }


### PR DESCRIPTION
Fix version of the base image and install dnsmasq dependency.
Also add error reporting to the script so that it exits immediately on error instead of silently failing and returning a 0 error code.