### PR TITLE
Fixups e2e

### DIFF
--- a/e2e/src/runner.c
+++ b/e2e/src/runner.c
@@ -242,7 +242,7 @@ static void device_object_callback(astarte_device_datastream_object_event_t even
     LOG_INF("Object received matched expected one");
 #else
     LOG_INF("Aggregate data received on %s%s", interface->name, event.base_event.path);
-    utils_log_e2e_object_entry_array(&received);
+    utils_log_object_entry_array(&received);
 #endif
 }
 

--- a/e2e/src/utilities.c
+++ b/e2e/src/utilities.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(utilities, CONFIG_UTILITIES_LOG_LEVEL); // NOLINT
 #define MAX_TS_STR_LEN 30
 
 // Maximum size for the datetime string
-#define DATETIME_MAX_BUF_SIZE 26
+#define DATETIME_MAX_BUF_SIZE 30
 
 /************************************************
  *         Static functions declaration         *
@@ -251,7 +251,7 @@ void utils_log_astarte_data(astarte_data_t data)
             }
             break;
         case ASTARTE_MAPPING_TYPE_DATETIME:
-            int64_t datetime = false;
+            int64_t datetime = 0;
             (void) astarte_data_to_datetime(data, &datetime);
             if (utils_datetime_to_string(datetime, tm_str) != 0) {
                 LOG_INF("Astarte datetime: %s", tm_str); // NOLINT

--- a/samples/astarte_app/src/utils.c
+++ b/samples/astarte_app/src/utils.c
@@ -38,7 +38,7 @@ const char *const utils_string_array_data[2] = { "Hello ", "world!" };
 // NOLINTEND(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)
 
 // Maximum size for the datetime string
-#define DATETIME_MAX_BUF_SIZE 26
+#define DATETIME_MAX_BUF_SIZE 30
 
 static size_t utils_datetime_to_string(
     int64_t datetime, char out_string[const DATETIME_MAX_BUF_SIZE]);
@@ -84,7 +84,7 @@ void utils_log_astarte_data(astarte_data_t data)
             }
             break;
         case ASTARTE_MAPPING_TYPE_DATETIME:
-            int64_t datetime = false;
+            int64_t datetime = 0;
             (void) astarte_data_to_datetime(data, &datetime);
             if (utils_datetime_to_string(datetime, tm_str) != 0) {
                 LOG_INF("Astarte datetime: %s", tm_str); // NOLINT


### PR DESCRIPTION
Fixes a function names in the e2e.
Raise the buffer size to 30 for the string converted from dates (technically 26 should be enough but not for every possible year value since that could be longer than 4 characters).
Change int literal initialization in dates